### PR TITLE
feat: Add wofi default support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A dmenu script to select the default audio source/sink in pipewire+wireplumber
 Map a key to `audiomenu select-source` and `audiomenu select-sink`
 
 You can set the dmenu program with `--menu 'fuzzel --dmenu'`. By default it
-will use the first available from `dmenu`, `dmenu-wl`, `rofi` and `fuzzel`.
+will use the first available from `dmenu`, `dmenu-wl`, `rofi`, `fuzzel` and `wofi`.
 
 ## Building
 

--- a/audiomenu.py
+++ b/audiomenu.py
@@ -93,7 +93,8 @@ def populate_volume(devices: list[AudioDevice]) -> None:
 
 
 def find_menuprog() -> str | None:
-    for prog in ["dmenu", "dmenu-wl", "rofi -dmenu", "fuzzel --dmenu"]:
+    for prog in ["dmenu", "dmenu-wl", "rofi -dmenu", "fuzzel --dmenu",
+                 "wofi --dmenu"]:
         if shutil.which(prog.split(" ")[0]) is not None:
             return prog
 


### PR DESCRIPTION
Hello there!

This is a cool script that I'm currently integrating into my system. While testing it out I noticed that default support for `wofi` is missing. I added support and tested the change.

Cheers!